### PR TITLE
fix/NUM_MENU_ITEMS

### DIFF
--- a/src/Esp8266_AT_WM_Lite.h
+++ b/src/Esp8266_AT_WM_Lite.h
@@ -206,9 +206,10 @@ class ESP_AT_WiFiManager_Lite
       // to avoid WebServer not working due to HTML data larger than 2K can't be sent successfully
       // The items with index larger than 3 will be ignored
       // Limit NUM_MENU_ITEMS to max 3     
+#if USE_DYNAMIC_PARAMETERS       
       if (NUM_MENU_ITEMS > 3)
         NUM_MENU_ITEMS = 3;
-           
+#endif           
       //// New DRD ////
       drd = new DoubleResetDetector_Generic(DRD_TIMEOUT, DRD_ADDRESS);  
       bool useConfigPortal = false;

--- a/src/Esp8266_AT_WM_Lite_DUE.h
+++ b/src/Esp8266_AT_WM_Lite_DUE.h
@@ -337,10 +337,11 @@ class ESP_AT_WiFiManager_Lite
       // Due to notorious 2K buffer limitation of ESP8266-AT shield, the NUM_MENU_ITEMS is limited to max 3
       // to avoid WebServer not working due to HTML data larger than 2K can't be sent successfully
       // The items with index larger than 3 will be ignored
-      // Limit NUM_MENU_ITEMS to max 3     
+      // Limit NUM_MENU_ITEMS to max 3    
+#if USE_DYNAMIC_PARAMETERS   
       if (NUM_MENU_ITEMS > 3)
         NUM_MENU_ITEMS = 3;
-           
+#endif           
       //// New DRD ////
       drd = new DoubleResetDetector_Generic(DRD_TIMEOUT, DRD_ADDRESS);  
       bool useConfigPortal = false;

--- a/src/Esp8266_AT_WM_Lite_RPi_Pico.h
+++ b/src/Esp8266_AT_WM_Lite_RPi_Pico.h
@@ -341,10 +341,11 @@ class ESP_AT_WiFiManager_Lite
       // Due to notorious 2K buffer limitation of ESP8266-AT shield, the NUM_MENU_ITEMS is limited to max 3
       // to avoid WebServer not working due to HTML data larger than 2K can't be sent successfully
       // The items with index larger than 3 will be ignored
-      // Limit NUM_MENU_ITEMS to max 3     
+      // Limit NUM_MENU_ITEMS to max 3   
+#if USE_DYNAMIC_PARAMETERS         
       if (NUM_MENU_ITEMS > 3)
         NUM_MENU_ITEMS = 3;
-           
+#endif           
       //// New DRD ////
       drd = new DoubleResetDetector_Generic(DRD_TIMEOUT, DRD_ADDRESS);  
       bool useConfigPortal = false;

--- a/src/Esp8266_AT_WM_Lite_SAMD.h
+++ b/src/Esp8266_AT_WM_Lite_SAMD.h
@@ -338,10 +338,11 @@ class ESP_AT_WiFiManager_Lite
       // Due to notorious 2K buffer limitation of ESP8266-AT shield, the NUM_MENU_ITEMS is limited to max 3
       // to avoid WebServer not working due to HTML data larger than 2K can't be sent successfully
       // The items with index larger than 3 will be ignored
-      // Limit NUM_MENU_ITEMS to max 3     
+      // Limit NUM_MENU_ITEMS to max 3  
+#if USE_DYNAMIC_PARAMETERS          
       if (NUM_MENU_ITEMS > 3)
         NUM_MENU_ITEMS = 3;
-           
+#endif           
       //// New DRD ////
       drd = new DoubleResetDetector_Generic(DRD_TIMEOUT, DRD_ADDRESS);  
       bool useConfigPortal = false;

--- a/src/Esp8266_AT_WM_Lite_STM32.h
+++ b/src/Esp8266_AT_WM_Lite_STM32.h
@@ -336,10 +336,11 @@ class ESP_AT_WiFiManager_Lite
       // Due to notorious 2K buffer limitation of ESP8266-AT shield, the NUM_MENU_ITEMS is limited to max 3
       // to avoid WebServer not working due to HTML data larger than 2K can't be sent successfully
       // The items with index larger than 3 will be ignored
-      // Limit NUM_MENU_ITEMS to max 3     
+      // Limit NUM_MENU_ITEMS to max 3  
+#if USE_DYNAMIC_PARAMETERS          
       if (NUM_MENU_ITEMS > 3)
         NUM_MENU_ITEMS = 3;
-           
+#endif           
       //// New DRD ////
       drd = new DoubleResetDetector_Generic(DRD_TIMEOUT, DRD_ADDRESS);  
       bool useConfigPortal = false;

--- a/src/Esp8266_AT_WM_Lite_nRF52.h
+++ b/src/Esp8266_AT_WM_Lite_nRF52.h
@@ -342,10 +342,11 @@ class ESP_AT_WiFiManager_Lite
       // Due to notorious 2K buffer limitation of ESP8266-AT shield, the NUM_MENU_ITEMS is limited to max 3
       // to avoid WebServer not working due to HTML data larger than 2K can't be sent successfully
       // The items with index larger than 3 will be ignored
-      // Limit NUM_MENU_ITEMS to max 3     
+      // Limit NUM_MENU_ITEMS to max 3  
+#if USE_DYNAMIC_PARAMETERS          
       if (NUM_MENU_ITEMS > 3)
         NUM_MENU_ITEMS = 3;
-           
+#endif           
       //// New DRD ////
       drd = new DoubleResetDetector_Generic(DRD_TIMEOUT, DRD_ADDRESS);  
       bool useConfigPortal = false;


### PR DESCRIPTION
Conditionally check for `NUM_MENU_ITEMS`

This fix ensures that the `NUM_MENU_ITEMS` value is only checked when `USE_DYNAMIC_PARAMETERS` is set to `true`.

Previously the compiler would yell with a message
```
'error: 'NUM_MENU_ITEMS' was not declared in this scope
  <arbitrary-line-number> |       if (NUM_MENU_ITEMS > 3)'
  ```